### PR TITLE
Disables Spring's built in transaction handling

### DIFF
--- a/src/main/java/com/impressdesigns/alex/Config.java
+++ b/src/main/java/com/impressdesigns/alex/Config.java
@@ -1,0 +1,11 @@
+package com.impressdesigns.alex;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableJpaRepositories(enableDefaultTransactions = false)
+@EnableTransactionManagement
+public class Config {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,25 +1,16 @@
+# Meta
 spring.application.name=alex
-
+# Database connection details
 spring.datasource.url=jdbc:filemaker://192.168.10.6/Data_ODBCMapping
 spring.datasource.username=redacted
 spring.datasource.password=redacted
+# Vendored FileMaker driver
 spring.datasource.driver-class-name=com.filemaker.jdbc.Driver
-
-# add the custom Hibernate Dialect to the classpath
-# and tell Spring to use it with FileMaker driver
-spring.jpa.properties.hibernate.dialect = com.impressdesigns.alex.FileMakerDialect
-
-# FM jdbc driver does not allow schema modifications, so disable updates
-spring.jpa.hibernate.ddl-auto = none
-
-
+# Custom dialect required because Hibernate doesn't have it's own
+spring.jpa.properties.hibernate.dialect=com.impressdesigns.alex.FileMakerDialect
+# Disable modifications because the database is read-only
+spring.datasource.hikari.read-only=true
+spring.datasource.hikari.auto-commit=false
+spring.jpa.hibernate.ddl-auto=none
+# Custom test query because the default one isn't supported by FileMaker
 spring.datasource.hikari.connection-test-query=SELECT Orders.ID_Order FROM Orders FETCH FIRST 1 ROWS ONLY
-
-
-# https://howtodoinjava.com/spring-boot2/hibernate-configuration-example/
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-
-spring.jpa.properties.hibernate.generate_statistics=true
-logging.level.org.hibernate.type=trace
-logging.level.org.hibernate.stat=debug

--- a/vendored/README.md
+++ b/vendored/README.md
@@ -1,0 +1,8 @@
+# Vendored files
+
+## `fmjdbc.jar`
+
+Proprietary closed-source JDBC driver for FileMaker Databases.
+
+See https://support.claris.com/s/article/Software-Update-FileMaker-xDBC-client-drivers-for-FileMaker-1503692806454 for
+updates.


### PR DESCRIPTION
Closes #4

- ref: https://www.baeldung.com/spring-transactions-read-only
- ref: https://www.baeldung.com/spring-boot-custom-auto-configuration

> Also, if using Spring Data JPA, it’s necessary to disable the default transactions created by Spring. Therefore, we only need to configure the enableDefaultTransactions property to false:

Apparently JPA handles it's own transactions, so disabling auto commit and adding read-only was working, JPA was just adding more on top of that. By disabling that too, we finally have a read only DB.